### PR TITLE
Match localized chat strings in PlaytimeStep

### DIFF
--- a/Auracite/Steps/PlaytimeStep.cs
+++ b/Auracite/Steps/PlaytimeStep.cs
@@ -1,3 +1,4 @@
+using System;
 using Dalamud.Game.Chat;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
@@ -32,13 +33,41 @@ public class PlaytimeStep : IStep
         return "Type /playtime into the chat window.";
     }
     
+    // Verbatim prefixes from LogMessage row 859 in the four supported client
+    // languages. Any whitespace or colon between the prefix and the value is
+    // stripped at extraction time so the same code path handles all four.
+    private static readonly string[] PlaytimeMarkers =
+    {
+        "Total Play Time",      // EN
+        "Temps de jeu total",   // FR
+        "Gesamtspielzeit",      // DE
+        "累積プレイ時間",         // JP — note: no colon between prefix and value
+    };
+
+    private static readonly char[] MarkerSeparators =
+    {
+        ':',        // EN, DE
+        ' ',        // ASCII space
+        ' ',   // NBSP — appears before the colon in FR
+        '　',   // ideographic space — possible in JP
+    };
+
     private void OnChatMessage(IHandleableChatMessage message)
     {
+        if (message.LogKind != XivChatType.SystemMessage) return;
         var msgString = message.Message.ToString();
-        if (msgString.Contains("Total Play Time:") && message.LogKind == XivChatType.SystemMessage)
+
+        foreach (var marker in PlaytimeMarkers)
         {
-            Plugin.package.playtime = msgString.Split(": ")[1]; // TODO: lol
+            var markerIdx = msgString.IndexOf(marker, StringComparison.Ordinal);
+            if (markerIdx < 0) continue;
+
+            var rest = msgString[(markerIdx + marker.Length)..]
+                .TrimStart(MarkerSeparators)
+                .TrimEnd();
+            Plugin.package.playtime = rest;
             Completed?.Invoke();
+            return;
         }
     }
 }


### PR DESCRIPTION
## Problem

`PlaytimeStep` waits for the chat system message produced by `/playtime`, but the existing check only matches the English string `"Total Play Time:"`. On non-English clients the chat message never matches, so the step never raises `Completed` and the export pipeline stalls there indefinitely.

I noticed this on a French client where the message is `Temps de jeu total : 1 jour, 18 heures, 55 minutes` — the substring check fails and the pipeline never advances past the Playtime step.

## Change

- Match against an array of localized markers (EN / FR / DE / JP).
- Replace the brittle `Split(": ")[1]` extraction with an `IndexOf(':', markerIdx) + 1` substring, then `Trim()`. This is also robust to the non-breaking space FFXIV uses before the colon in French (`"total :"`), which would have broken the previous `Split(": ")` split even if the contains-check had passed.

The DE / JP markers are best-effort based on the conventional translations; if they're wrong the worst case is the step still stalls on those clients (no behavior change for them vs. today).

## Testing

Built and tested live on a 7.5 client (FR, API 15). The chat message `"Temps de jeu total : 1 jour, 18 heures, 55 minutes"` is now matched and the step advances to the next stage as expected. EN markers were preserved verbatim, so existing English-client behavior is unchanged.