### PR TITLE
Fix NullReferenceException loop in AdventurerPlateStep

### DIFF
--- a/Auracite/Steps/AdventurerPlateStep.cs
+++ b/Auracite/Steps/AdventurerPlateStep.cs
@@ -33,7 +33,9 @@ public class AdventurerPlateStep : IStep
             unsafe
             {
                 var storage = AgentCharaCard.Instance()->Data;
-                var image = GetCurrentCharaViewImage();;
+                if (storage == null) return;
+                var image = GetCurrentCharaViewImage();
+                if (image == null) return; // texture not ready yet, retry next frame
 
                 var plateDesign = storage->PlateDesign;
                 
@@ -101,9 +103,16 @@ public class AdventurerPlateStep : IStep
         }
     }
     
-    public unsafe Image GetCurrentCharaViewImage()
+    public unsafe Image? GetCurrentCharaViewImage()
     {
-        var texture = CppObject.FromPointer<Texture2D>((nint)AgentCharaCard.Instance()->Data->PortraitTexture->D3D11Texture2D);
+        var data = AgentCharaCard.Instance()->Data;
+        if (data == null) return null;
+        var portraitTexture = data->PortraitTexture;
+        if (portraitTexture == null) return null;
+        var d3d11Texture = portraitTexture->D3D11Texture2D;
+        if (d3d11Texture == null) return null;
+
+        var texture = CppObject.FromPointer<Texture2D>((nint)d3d11Texture);
         var device = (Device5)(IntPtr)FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Device.Instance()->D3D11Forwarder;
         
         // Copy to a CPU-mapped staging texture 


### PR DESCRIPTION
## Problem

`AdventurerPlateStep.NeedsUpdateEveryFrame()` returns true so `Run()` is invoked every frame while the Adventurer Plate window is open. On the very first frames after the window opens (and apparently on some 7.5 sessions in general), `AgentCharaCard.Instance()->Data->PortraitTexture` or its `D3D11Texture2D` pointer can still be null, but `GetCurrentCharaViewImage` dereferences both unconditionally.

The result is a tight loop of `System.NullReferenceException` thrown from `GetCurrentCharaViewImage`, swallowed by Dalamud's per-event `PluginErrorHandler`, and printed as `[ERR]` once per frame in `dalamud.log` — the step also never reaches `Completed?.Invoke()` until the texture happens to be ready.

```
[ERR] [Auracite] Exception in event handler IFramework::Update
System.NullReferenceException: Object reference not set to an instance of an object.
   at Auracite.AdventurerPlateStep.GetCurrentCharaViewImage() in …/AdventurerPlateStep.cs:line 106
   at Auracite.AdventurerPlateStep.Run() in …/AdventurerPlateStep.cs:line 36
```

## Change

- Walk the `AgentCharaCard.Instance()->Data->PortraitTexture->D3D11Texture2D` pointer chain step by step inside `GetCurrentCharaViewImage`, returning `Image?` and bailing out at the first null link.
- In `Run()`, also check `storage` for null and bail out when `GetCurrentCharaViewImage` returns null. The next frame retries.

When the texture is ready the existing happy-path runs unchanged and `Completed` fires exactly once. The error-spam in `dalamud.log` goes away on slow open.

## Testing

Built and tested live on a 7.5 client (FR, API 15). Opening the Adventurer Plate now produces no `[ERR]` lines for `Auracite` and the step advances cleanly to the next stage. Verified the export still produces valid `base-plate.png`, `backing.png`, etc. in the resulting archive.