### PR TITLE
Dispose the current step in Plugin.Stop

### DIFF
--- a/Auracite/Plugin.cs
+++ b/Auracite/Plugin.cs
@@ -94,6 +94,7 @@ public sealed class Plugin : IDalamudPlugin
 
     public void Stop()
     {
+        CurrentStep?.Dispose();
         CurrentStep = null;
         StepWindow.IsOpen = false;
         package = null;


### PR DESCRIPTION
## Problem

When the user clicks **Close** on the End step, `Plugin.Stop()` sets `CurrentStep` to null without calling `Dispose()` on it first:

```csharp
public void Stop()
{
    CurrentStep = null;
    StepWindow.IsOpen = false;
    package = null;
}
```

`EndStep` owns an EmbedIO `WebServer` bound to `http://localhost:42073/` — started in `Run`, torn down in `Dispose`. With Stop bypassing Dispose, the server keeps listening on 42073 for the rest of the game session and the step's resources leak. The same shape of leak applies to any other step that subscribes to events in its constructor: `PlaytimeStep` for instance hooks `ChatGui.ChatMessage` in `.ctor` and unhooks it in `Dispose`.

I noticed this while clicking Close after the export finished — the window dismissed, but `ss -tlnp` still showed the EmbedIO listener attached to ffxiv_dx11.exe.

## Change

Call `CurrentStep?.Dispose()` before nulling the field. One-line change.

`NextStep()` already disposes the step on the natural end-of-pipeline path (`_stepIndex >= _steps.Count`), so this just makes the `Stop()` codepath behave consistently.

## Testing

After the change, clicking Close on the End step shuts the EmbedIO listener down (verified — port 42073 no longer in `ss -tlnp` output). No behavioral change to the success path.