### PR TITLE
Add missing InventoryType.ArmoryFeets

### DIFF
--- a/Auracite/Package.cs
+++ b/Auracite/Package.cs
@@ -135,6 +135,7 @@ public class CharacterJson
     public InventoryContainer? armory_hands;
     public InventoryContainer? armory_waist;
     public InventoryContainer? armory_legs;
+    public InventoryContainer? armory_feets;
     public InventoryContainer? armory_ear;
     public InventoryContainer? armory_neck;
     public InventoryContainer? armory_wrist;

--- a/Auracite/Steps/InventoryStep.cs
+++ b/Auracite/Steps/InventoryStep.cs
@@ -29,6 +29,7 @@ public class InventoryStep : IStep
                 Plugin.package.armory_hands = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryHands));
                 Plugin.package.armory_waist = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryWaist));
                 Plugin.package.armory_legs = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryLegs));
+                Plugin.package.armory_feets = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryFeets));
                 Plugin.package.armory_ear = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryEar));
                 Plugin.package.armory_neck = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryNeck));
                 Plugin.package.armory_wrist = ProcessContainer(manager->GetInventoryContainer(InventoryType.ArmoryWrist));


### PR DESCRIPTION
Very small change, InventoryType.ArmoryFeets was not being exported at all, this commit adds it to the export